### PR TITLE
891533: Infinite loop occurs in Recurrence Helper has been fixed.

### DIFF
--- a/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
+++ b/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
@@ -679,7 +679,6 @@ namespace CoreWebApp
                         else if (UNTIL != null)
                         {
                             bool IsUntilDateReached = false;
-                            DateTime prevDate = new DateTime();
                             while (!IsUntilDateReached)
                             {
                                 var weekCount = MondaysInMonth(addDate);
@@ -727,19 +726,33 @@ namespace CoreWebApp
                                     var lastDate = ScheduleUtils.LastDateOfMonth(monthStart);
                                     addDate = ScheduleUtils.GetWeekFirstDate(lastDate, nthweekDay);
                                 }
+                                if(setPosCount == 0)
+                                {
+                                    while(!IsUntilDateReached)
+                                    {
+                                        if(int.Parse(BYMONTHCOUNT) == addDate.Month)
+                                        {
+                                            GetWeeklyDateCollection(addDate,weeklyRule,RecDateCollection);
+                                            addDate = addDate.AddDays(1);
+                                        }
+                                        else
+                                        {
+                                            addDate = addDate.AddMonths(1);
+                                        }
+                                        if(addDate.CompareTo(endDate) > 0)
+                                        {
+                                            IsUntilDateReached = true;
+                                        }
+                                    }   
+                                }
                                 else
                                 {
                                     addDate = weekStartDate.AddDays((nthWeek) * 7);
                                     addDate = addDate.AddDays(nthweekDay);
-                                    if (addDate.CompareTo(prevDate) < 0)
-                                    {
-                                        addDate = prevDate;
-                                    }
                                 }
                                 if (addDate.CompareTo(startDate.Date) < 0)
                                 {
                                     addDate = addDate.AddYears(1);
-                                    prevDate = addDate;
                                     continue;
                                 }
                                 if (DateTime.Compare(addDate.Date, Convert.ToDateTime(UNTIL)) <= 0)

--- a/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
+++ b/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
@@ -686,7 +686,7 @@ namespace CoreWebApp
                                 var monthStart = new DateTime(addDate.Year, monthIndex, 1);
                                 DateTime weekStartDate = monthStart.AddDays(-(int)(monthStart.DayOfWeek));
                                 var monthStartWeekday = (int)(monthStart.DayOfWeek);
-                                int nthweekDay = GetWeekDay(BYDAYVALUE);
+                                int nthweekDay = GetWeekDay(BYDAYVALUE) - 1;
                                 int nthWeek;
                                 int bySetPos = 0;
                                 int setPosCount;

--- a/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
+++ b/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
@@ -685,7 +685,7 @@ namespace CoreWebApp
                                 var monthStart = new DateTime(addDate.Year, monthIndex, 1);
                                 DateTime weekStartDate = monthStart.AddDays(-(int)(monthStart.DayOfWeek));
                                 var monthStartWeekday = (int)(monthStart.DayOfWeek);
-                                int nthweekDay = GetWeekDay(BYDAYVALUE) - 1;
+                                int nthweekDay = GetWeekDay(BYDAYVALUE);
                                 int nthWeek;
                                 int bySetPos = 0;
                                 int setPosCount;

--- a/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
+++ b/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
@@ -679,6 +679,7 @@ namespace CoreWebApp
                         else if (UNTIL != null)
                         {
                             bool IsUntilDateReached = false;
+                            DateTime prevDate = new DateTime();
                             while (!IsUntilDateReached)
                             {
                                 var weekCount = MondaysInMonth(addDate);
@@ -730,10 +731,15 @@ namespace CoreWebApp
                                 {
                                     addDate = weekStartDate.AddDays((nthWeek) * 7);
                                     addDate = addDate.AddDays(nthweekDay);
+                                    if (addDate.CompareTo(prevDate) < 0)
+                                    {
+                                        addDate = prevDate;
+                                    }
                                 }
                                 if (addDate.CompareTo(startDate.Date) < 0)
                                 {
                                     addDate = addDate.AddYears(1);
+                                    prevDate = addDate;
                                     continue;
                                 }
                                 if (DateTime.Compare(addDate.Date, Convert.ToDateTime(UNTIL)) <= 0)

--- a/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
+++ b/Parse_Recurrece_Rule/CoreWebApp/Models/RecurrenceHelper.cs
@@ -726,24 +726,24 @@ namespace CoreWebApp
                                     var lastDate = ScheduleUtils.LastDateOfMonth(monthStart);
                                     addDate = ScheduleUtils.GetWeekFirstDate(lastDate, nthweekDay);
                                 }
-                                if(setPosCount == 0)
+                                else if (setPosCount == 0)
                                 {
-                                    while(!IsUntilDateReached)
+                                    while (!IsUntilDateReached)
                                     {
-                                        if(int.Parse(BYMONTHCOUNT) == addDate.Month)
+                                        if (int.Parse(BYMONTHCOUNT) == addDate.Month)
                                         {
-                                            GetWeeklyDateCollection(addDate,weeklyRule,RecDateCollection);
+                                            GetWeeklyDateCollection(addDate, weeklyRule, RecDateCollection);
                                             addDate = addDate.AddDays(1);
                                         }
                                         else
                                         {
                                             addDate = addDate.AddMonths(1);
                                         }
-                                        if(addDate.CompareTo(endDate) > 0)
+                                        if (addDate.CompareTo(endDate) > 0)
                                         {
                                             IsUntilDateReached = true;
                                         }
-                                    }   
+                                    }
                                 }
                                 else
                                 {


### PR DESCRIPTION
### Bug description
Infinite loop occurs in Recurrence Helper for the given recurrence rule. "FREQ=YEARLY;BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA;UNTIL=20250131T235959Z"

### Root cause
The recurrence rule provided by the customer contains multiple BYDAY values and does not include a BYSETPOS value. The existing code, which is designed to handle only one BYDAY value and BYSETPOS when it’s “-1” or less than 0 for that specific rule provided by customer, results in an infinite loop due to the missing BYSETPOS value.

### Solution description
I resolved this issue by incorporating the BYSETPOS value when it is 0 or missing. I also managed the multiple BYDAY values in accordance with the given recurrence rule. This will generate the correct dates, regardless of whether the BYSETPOS value is present or not.